### PR TITLE
[upd] aws-anyscale-iam - tighten policy for service linked role creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.10.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- Additional tightening of policies around Service Linked Role creation.
+
+BREAKING CHANGES:
+
 ## 0.10.0 (Released)
 FEATURES:
 

--- a/modules/aws-anyscale-iam/iam-policies-data.tf
+++ b/modules/aws-anyscale-iam/iam-policies-data.tf
@@ -92,17 +92,17 @@ data "aws_iam_policy_document" "iam_anyscale_steadystate_policy" {
       values   = ["spot.amazonaws.com"]
     }
   }
-  statement {
-    sid    = "UpdateSpotServiceRole"
-    effect = "Allow"
-    actions = [
-      "iam:AttachRolePolicy",
-      "iam:PutRolePolicy",
-    ]
-    resources = [
-      "arn:aws:iam::${local.account_id}:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot"
-    ]
-  }
+  # statement {
+  #   sid    = "UpdateSpotServiceRole"
+  #   effect = "Allow"
+  #   actions = [
+  #     "iam:AttachRolePolicy",
+  #     "iam:PutRolePolicy",
+  #   ]
+  #   resources = [
+  #     "arn:aws:iam::${local.account_id}:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot"
+  #   ]
+  # }
 
   dynamic "statement" {
     for_each = local.cloud_id_provided ? [] : [1]
@@ -392,17 +392,17 @@ data "aws_iam_policy_document" "iam_anyscale_services_v2" {
       values   = ["elasticloadbalancing.amazonaws.com"]
     }
   }
-  statement {
-    sid    = "UpdateELBServiceLinkedRole"
-    effect = "Allow"
-    actions = [
-      "iam:AttachRolePolicy",
-      "iam:PutRolePolicy",
-    ]
-    resources = [
-      "arn:aws:iam::${local.account_id}:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
-    ]
-  }
+  # statement {
+  #   sid    = "UpdateELBServiceLinkedRole"
+  #   effect = "Allow"
+  #   actions = [
+  #     "iam:AttachRolePolicy",
+  #     "iam:PutRolePolicy",
+  #   ]
+  #   resources = [
+  #     "arn:aws:iam::${local.account_id}:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
+  #   ]
+  # }
 
   statement {
     sid    = "ELBRead"


### PR DESCRIPTION
Removed PutRolePolicy and AttachRolePolicy from the policies for creating the Service Linked Roles for Spot and Elastic Load Balancing. On branch release-0.10.1
Changes to be committed:
	modified:   CHANGELOG.md
	modified:   modules/aws-anyscale-iam/iam-policies-data.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

