### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.13.0 (Released)
+FEATURES:
+- Update to latest AWS Provider (v5.x)
+- IAM SubModule - Allow alternative trusted role arn for automated testing
+
+## 0.12.0 (Unreleased)
+FEATURES:
+
+BUG FIXES:
+
+BREAKING CHANGES:
+
+NOTES:
+Forced new deploy as Terraform Registry wasn't picking this release up correctly.
+
 ## 0.11.1 (Released)
 FEATURES:
 


### PR DESCRIPTION
[upd] IAM SubModule - Allow alternative trusted role arn for testing To automate testing of the Terraform modules, we need to be able to pass in a non-production role arn to the IAM submodule. This change allows the automated testing to pass in a new trusted role arn. This parameter should not be used by any users and defaults to null in the root module.

[upd] AWS Terraform Provider to ~> 5.0
Includes updates to VPC module to support new provider and deprecated settings for EIP.

On branch release-0.13.0
Changes to be committed:
	modified:   CHANGELOG.md

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation change
- [ ] Other (please describe):

