### PR TITLE
[add] example - anyscale-v2-existing-s3

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.21.1"
+  version = "0.24.3"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/examples/anyscale-v2-existing-s3/README.md
+++ b/examples/anyscale-v2-existing-s3/README.md
@@ -1,0 +1,87 @@
+# Anyscale Networking Stack v2 - Existing S3 Bucket
+
+This **example** will build the resources necessary to run Anyscale in an AWS account. It requires an existing S3 bucket and will not run the `anyscale-s3-module` submodule.
+
+This example will build a
+[Direct Networking](https://docs.anyscale.com/cloud-deployment/aws/manage-clouds#anyscale-clouds-on-aws) solution. The resources built by this Terraform will all have a common name prefix.
+
+
+## To execute
+A general understanding of Terraform and AWS are useful for executing this Terraform. For a high level overview of both,
+please see the [getting started guide](https://github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules/blob/main/getting-started.md).
+
+## Using with the Anyscale CLI
+
+The outputs from this Terraform can be used to build an anyscale cloud with the anyscale CLI. To use:
+1. Make sure you have the latest Anyscale CLI installed `pip install anyscale --upgrade`
+2. The terraform output, `anyscale_register_command` will provide an example Anyscale CLI command that can be used to register an Anyscale Cloud. You will need to change `<CUSTOMER_DEFINED_NAME>` to a cloud name that you would like to use.
+
+example:
+
+```
+anyscale cloud register --provider aws \
+  --name <CUSTOMER_DEFINED_NAME> \
+  --region <VPC_REGION> \
+  --vpc-id <VPC ID FROM Outputs> \
+  --subnet-ids <SUBNET_ID1>,<SUBNET_ID2>,<SUBNET_ID3>,<SUBNET_ID4> \
+  --efs-id <FILE_SYSTEM_ID> \
+  --anyscale-iam-role-id <ANYSCALE_IAM_ROLE_ARN> \
+  --instance-iam-role-id <INSTANCE_IAM_ROLE_ARN> \
+  --security-group-ids <SECURITY_GROUP_ID> \
+  --s3-bucket-id <S3_BUCKET_NAME>
+
+anyscale cloud verify --name <CUSTOMER_DEFINED_NAME>
+anyscale cloud delete --name <CUSTOMER_DEFINED_NAME>
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_anyscale_v2_common_name"></a> [aws\_anyscale\_v2\_common\_name](#module\_aws\_anyscale\_v2\_common\_name) | ../.. | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region in which all resources will be created.<br>ex:<pre>aws_region = "us-east-2"</pre> | `string` | n/a | yes |
+| <a name="input_customer_ingress_cidr_ranges"></a> [customer\_ingress\_cidr\_ranges](#input\_customer\_ingress\_cidr\_ranges) | The IPv4 CIDR block that is allowed to access the clusters.<br>This provides the ability to lock down the v1 stack to just the public IPs of a corporate network.<br>This is added to the security group and allows port 443 (https) and 22 (ssh) access.<br><br>While not recommended, you can set this to `0.0.0.0/0` to allow access from anywhere.<br>ex:<pre>customer_ingress_cidr_ranges = "52.1.1.23/32,10.1.0.0/16"</pre> | `string` | n/a | yes |
+| <a name="input_existing_s3_bucket_arn"></a> [existing\_s3\_bucket\_arn](#input\_existing\_s3\_bucket\_arn) | (Required) S3 Bucket Arn<br>The ARN of an existing S3 bucket to use for the Anyscale v2 stack.<br>This bucket must be in the same region as the stack.<br>ex:<pre>existing_s3_bucket_arn = "arn:aws:s3:::my-existing-bucket"</pre> | `string` | n/a | yes |
+| <a name="input_anyscale_cloud_id"></a> [anyscale\_cloud\_id](#input\_anyscale\_cloud\_id) | (Optional) Anyscale Cloud ID.<br>This is used to lock down the cross account access role by Cloud ID. Because the Cloud ID is unique to each<br>customer, this ensures that only the customer can access their own resources. The Cloud ID is not known until the<br>Cloud is created, so this is an optional variable.<br>ex:<pre>anyscale_cloud_id = "cld_abcdefghijklmnop1234567890"</pre> | `string` | `null` | no |
+| <a name="input_anyscale_deploy_env"></a> [anyscale\_deploy\_env](#input\_anyscale\_deploy\_env) | (Optional) Anyscale deployment environment. Used in resource names and tags.<br>ex:<pre>anyscale_deploy_env = "production"</pre> | `string` | `"production"` | no |
+| <a name="input_anyscale_org_id"></a> [anyscale\_org\_id](#input\_anyscale\_org\_id) | (Optional) Anyscale Organization ID.<br><br>This is used to lock down the cross account access role by Organization ID. Because the Organization ID is unique to each<br>customer, this ensures that only the customer can access their own resources.<br><br>ex:<pre>anyscale_org_id = "org_abcdefghijklmn1234567890"</pre> | `string` | `null` | no |
+| <a name="input_common_prefix"></a> [common\_prefix](#input\_common\_prefix) | (Optional)<br>Default for this EXAMPLE is `anyscale-pfx-test-` | `string` | `"anyscale-pfx-test-"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags.<br>These tags will be added to all cloud resources that accept tags.<br>ex:<pre>tags = {<br>  "environment" = "test",<br>  "team" = "anyscale"<br>}</pre> | `map(string)` | <pre>{<br>  "environment": "test",<br>  "test": true<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_anyscale_register_command"></a> [anyscale\_register\_command](#output\_anyscale\_register\_command) | Anyscale register command.<br>This output can be used with the Anyscale CLI to register a new Anyscale Cloud.<br>You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command. |
+| <a name="output_anyscale_v2_efs_id"></a> [anyscale\_v2\_efs\_id](#output\_anyscale\_v2\_efs\_id) | Anyscale Elastic File System ID. |
+| <a name="output_anyscale_v2_iam_instance_role_arn"></a> [anyscale\_v2\_iam\_instance\_role\_arn](#output\_anyscale\_v2\_iam\_instance\_role\_arn) | Anyscale IAM instance role arn. |
+| <a name="output_anyscale_v2_iam_role_arn"></a> [anyscale\_v2\_iam\_role\_arn](#output\_anyscale\_v2\_iam\_role\_arn) | Anyscale IAM access role arn. |
+| <a name="output_anyscale_v2_private_routetable_ids"></a> [anyscale\_v2\_private\_routetable\_ids](#output\_anyscale\_v2\_private\_routetable\_ids) | Anyscale VPC Private Route Table IDs. If none were created, return an empty string. |
+| <a name="output_anyscale_v2_private_subnet_ids"></a> [anyscale\_v2\_private\_subnet\_ids](#output\_anyscale\_v2\_private\_subnet\_ids) | Anyscale VPC Private Subnet IDs. If there were none created, return an empty string. |
+| <a name="output_anyscale_v2_public_routetable_ids"></a> [anyscale\_v2\_public\_routetable\_ids](#output\_anyscale\_v2\_public\_routetable\_ids) | Anyscale VPC Public Route Table IDs. If none were created, return an empty string. |
+| <a name="output_anyscale_v2_public_subnet_ids"></a> [anyscale\_v2\_public\_subnet\_ids](#output\_anyscale\_v2\_public\_subnet\_ids) | Anyscale VPC Public Subnet IDs. If there were none created, return an empty string. |
+| <a name="output_anyscale_v2_s3_bucket_id"></a> [anyscale\_v2\_s3\_bucket\_id](#output\_anyscale\_v2\_s3\_bucket\_id) | Anyscale S3 Bucket ID. If a bucket was not created, return an empty string. |
+| <a name="output_anyscale_v2_security_group_id"></a> [anyscale\_v2\_security\_group\_id](#output\_anyscale\_v2\_security\_group\_id) | Anyscale Security Group ID. If a security group was not created, return an empty string. |
+| <a name="output_anyscale_v2_vpc_id"></a> [anyscale\_v2\_vpc\_id](#output\_anyscale\_v2\_vpc\_id) | Anyscale VPC ID. If there was not one created, return the one that was used during other resource creation. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/anyscale-v2-existing-s3/main.tf
+++ b/examples/anyscale-v2-existing-s3/main.tf
@@ -1,0 +1,44 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Create core Anyscale v2 Stack resources with minimal parameters but a common name
+#   Should be executed in us-east-2
+#   Creates a v2 stack including
+#     - IAM Roles
+#     - S3 Bucket
+#     - VPC with publicly routed subnets (no private subnets)
+#     - VPC Security Groups
+#     - EFS
+# ---------------------------------------------------------------------------------------------------------------------
+locals {
+  full_tags = merge(tomap({
+    anyscale-cloud-id           = var.anyscale_cloud_id,
+    anyscale-deploy-environment = var.anyscale_deploy_env
+    }),
+    var.tags
+  )
+}
+
+module "aws_anyscale_v2_common_name" {
+  source = "../.." #this should be changed if executing this example outside of this repository
+  tags   = local.full_tags
+
+  anyscale_deploy_env = var.anyscale_deploy_env
+  anyscale_cloud_id   = var.anyscale_cloud_id
+  anyscale_org_id     = var.anyscale_org_id
+
+  create_cluster_node_cloudwatch_policy = true
+
+  existing_s3_bucket_arn = var.existing_s3_bucket_arn
+
+  # VPC Related
+  anyscale_vpc_cidr_block     = "172.24.0.0/16"
+  anyscale_vpc_public_subnets = ["172.24.21.0/24", "172.24.22.0/24", "172.24.23.0/24"]
+  # anyscale_vpc_private_subnets = ["172.24.101.0/24", "172.24.102.0/24", "172.24.103.0/24"]
+
+  common_prefix   = var.common_prefix
+  use_common_name = true
+
+  # Security Group Related
+  security_group_ingress_allow_access_from_cidr_range = var.customer_ingress_cidr_ranges
+
+
+}

--- a/examples/anyscale-v2-existing-s3/outputs.tf
+++ b/examples/anyscale-v2-existing-s3/outputs.tf
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Anyscale v2 Stack resources with common name
+# ---------------------------------------------------------------------------------------------------------------------
+output "anyscale_v2_vpc_id" {
+  description = "Anyscale VPC ID. If there was not one created, return the one that was used during other resource creation."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_id, "")
+}
+
+output "anyscale_v2_public_routetable_ids" {
+  description = "Anyscale VPC Public Route Table IDs. If none were created, return an empty string."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_public_routetable_ids, [])
+}
+output "anyscale_v2_public_subnet_ids" {
+  description = "Anyscale VPC Public Subnet IDs. If there were none created, return an empty string."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_public_subnet_ids, [])
+}
+output "anyscale_v2_private_routetable_ids" {
+  description = "Anyscale VPC Private Route Table IDs. If none were created, return an empty string."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_private_routetable_ids, [])
+}
+output "anyscale_v2_private_subnet_ids" {
+  description = "Anyscale VPC Private Subnet IDs. If there were none created, return an empty string."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_private_subnet_ids, [])
+}
+
+output "anyscale_v2_s3_bucket_id" {
+  description = "Anyscale S3 Bucket ID. If a bucket was not created, return an empty string."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_s3_bucket_id, "")
+}
+
+output "anyscale_v2_security_group_id" {
+  description = "Anyscale Security Group ID. If a security group was not created, return an empty string."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_security_group_id, "")
+}
+
+output "anyscale_v2_iam_role_arn" {
+  description = "Anyscale IAM access role arn."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_iam_role_arn, "")
+}
+
+output "anyscale_v2_iam_instance_role_arn" {
+  description = "Anyscale IAM instance role arn."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_iam_role_cluster_node_arn, "")
+}
+
+output "anyscale_v2_efs_id" {
+  description = "Anyscale Elastic File System ID."
+  value       = try(module.aws_anyscale_v2_common_name.anyscale_efs_id, "")
+}
+
+output "anyscale_register_command" {
+  description = <<-EOF
+    Anyscale register command.
+    This output can be used with the Anyscale CLI to register a new Anyscale Cloud.
+    You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command.
+  EOF
+  value       = "anyscale cloud register --provider aws \\\n--name <CUSTOMER_DEFINED_NAME> \\\n--region ${var.aws_region} \\\n--vpc-id ${module.aws_anyscale_v2_common_name.anyscale_vpc_id} \\\n--subnet-ids ${join(",", module.aws_anyscale_v2_common_name.anyscale_vpc_public_subnet_ids)} \\\n--security-group-ids ${module.aws_anyscale_v2_common_name.anyscale_security_group_id} \\\n--s3-bucket-id ${module.aws_anyscale_v2_common_name.anyscale_s3_bucket_id} \\\n--anyscale-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_arn} \\\n--instance-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_cluster_node_arn} \\\n--efs-id ${module.aws_anyscale_v2_common_name.anyscale_efs_id}"
+}

--- a/examples/anyscale-v2-existing-s3/variables.tf
+++ b/examples/anyscale-v2-existing-s3/variables.tf
@@ -1,0 +1,154 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# Define these secrets as environment variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED VARIABLES
+# These variables must be set when using this module.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = <<-EOF
+    The AWS region in which all resources will be created.
+    ex:
+    ```
+    aws_region = "us-east-2"
+    ```
+  EOF
+  type        = string
+}
+
+variable "customer_ingress_cidr_ranges" {
+  description = <<-EOT
+    The IPv4 CIDR block that is allowed to access the clusters.
+    This provides the ability to lock down the v1 stack to just the public IPs of a corporate network.
+    This is added to the security group and allows port 443 (https) and 22 (ssh) access.
+
+    While not recommended, you can set this to `0.0.0.0/0` to allow access from anywhere.
+    ex:
+    ```
+    customer_ingress_cidr_ranges = "52.1.1.23/32,10.1.0.0/16"
+    ```
+  EOT
+  type        = string
+}
+
+variable "existing_s3_bucket_arn" {
+  description = <<-EOT
+    (Required) S3 Bucket Arn
+    The ARN of an existing S3 bucket to use for the Anyscale v2 stack.
+    This bucket must be in the same region as the stack.
+    ex:
+    ```
+    existing_s3_bucket_arn = "arn:aws:s3:::my-existing-bucket"
+    ```
+  EOT
+  type        = string
+}
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These variables have defaults, but may be overridden.
+# ------------------------------------------------------------------------------
+variable "anyscale_deploy_env" {
+  description = <<-EOF
+    (Optional) Anyscale deployment environment. Used in resource names and tags.
+    ex:
+    ```
+    anyscale_deploy_env = "production"
+    ```
+  EOF
+  type        = string
+  validation {
+    condition = (
+      var.anyscale_deploy_env == "production" || var.anyscale_deploy_env == "development" || var.anyscale_deploy_env == "test"
+    )
+    error_message = "The anyscale_deploy_env only allows `production`, `test`, or `development`"
+  }
+  default = "production"
+}
+
+variable "anyscale_cloud_id" {
+  description = <<-EOF
+    (Optional) Anyscale Cloud ID.
+    This is used to lock down the cross account access role by Cloud ID. Because the Cloud ID is unique to each
+    customer, this ensures that only the customer can access their own resources. The Cloud ID is not known until the
+    Cloud is created, so this is an optional variable.
+    ex:
+    ```
+    anyscale_cloud_id = "cld_abcdefghijklmnop1234567890"
+    ```
+  EOF
+  type        = string
+  default     = null
+  validation {
+    condition = (
+      var.anyscale_cloud_id == null ? true : (
+        length(var.anyscale_cloud_id) > 4 &&
+        substr(var.anyscale_cloud_id, 0, 4) == "cld_"
+      )
+    )
+    error_message = "The anyscale_cloud_id value must start with \"cld_\"."
+  }
+}
+
+variable "anyscale_org_id" {
+  description = <<-EOT
+    (Optional) Anyscale Organization ID.
+
+    This is used to lock down the cross account access role by Organization ID. Because the Organization ID is unique to each
+    customer, this ensures that only the customer can access their own resources.
+
+    ex:
+    ```
+    anyscale_org_id = "org_abcdefghijklmn1234567890"
+    ```
+  EOT
+  type        = string
+  default     = null
+  validation {
+    condition = (
+      var.anyscale_org_id == null ? true : (
+        length(var.anyscale_org_id) > 4 &&
+        substr(var.anyscale_org_id, 0, 4) == "org_"
+      )
+    )
+    error_message = "The anyscale_org_id value must start with \"org_\"."
+  }
+}
+
+variable "tags" {
+  description = <<-EOF
+    (Optional) A map of tags.
+    These tags will be added to all cloud resources that accept tags.
+    ex:
+    ```
+    tags = {
+      "environment" = "test",
+      "team" = "anyscale"
+    }
+    ```
+  EOF
+  type        = map(string)
+  default = {
+    "test" : true,
+    "environment" : "test"
+  }
+}
+
+
+variable "common_prefix" {
+  description = <<-EOT
+    (Optional)
+    Default for this EXAMPLE is `anyscale-pfx-test-`
+  EOT
+  type        = string
+  default     = "anyscale-pfx-test-"
+  validation {
+    condition     = var.common_prefix == null || try(length(var.common_prefix) <= 30, false)
+    error_message = "common_prefix must either be `null` or less than 30 characters."
+  }
+}

--- a/examples/anyscale-v2-existing-s3/versions.tf
+++ b/examples/anyscale-v2-existing-s3/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}


### PR DESCRIPTION
## New Example - Existing S3 Bucket

Add an example of using an existing S3 bucket with these Terraform modules.
This skips creating the S3 bucket and instead uses an existing bucket.

On branch brent/add-existings3-example
Changes to be committed:
	new file:   examples/anyscale-v2-existing-s3/README.md
	new file:   examples/anyscale-v2-existing-s3/main.tf
	new file:   examples/anyscale-v2-existing-s3/outputs.tf
	new file:   examples/anyscale-v2-existing-s3/variables.tf
	new file:   examples/anyscale-v2-existing-s3/versions.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation change
- [x] Other (please describe):
Additional example
Update to tflint version

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

