### PR TITLE
[upd] Root Module - Fix IAM trust policy for cross account access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 0.15.3 (Released)
+FEATURES:
+
+BUG FIXES:
+- Fix repetive executions removing assume rule condition when anyscale_cloud_id was null or ""
+
+BREAKING CHANGES:
+
+
+## 0.15.2 (Released)
+FEATURES:
+
+BUG FIXES:
+
+BREAKING CHANGES:
+
+NOTES:
+- New example added for existing S3 bucket
+
+
+## 0.15.1 (Released)
+FEATURES:
+
+BUG FIXES:
+
+BREAKING CHANGES:
+
+NOTES:
+- Cleaned up the descriptions of the root module's variables.tf file to make it easier to read and understand.
+
+
 ## 0.15.0 (Released)
 FEATURES:
 - New IAM policy to allow writing AWS Cloudwatch logs and metrics. This is an optional policy controlled via variable. See the [readme.md](./README.md) for more information and the Anyscale Docs for [Cloudwatch logging](https://docs.anyscale.com/integrations/monitoring).

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,8 @@ locals {
   cluster_node_cloudwatch_policy_prfx = var.anyscale_cluster_node_cloudwatch_policy_prefix != null ? var.anyscale_cluster_node_cloudwatch_policy_prefix : local.common_name != null ? "${local.common_name}-clusternode-cloudwatch-policy-" : null
   iam_accessrole_custom_policy_name   = var.anyscale_accessrole_custom_policy_name != null ? var.anyscale_accessrole_custom_policy_name : local.common_name != null ? "${local.common_name}-crossacct-custom-policy" : null
   iam_s3_policy_name                  = var.anyscale_iam_s3_policy_name != null ? var.anyscale_iam_s3_policy_name : local.common_name != null ? "${local.common_name}-s3-policy" : null
+
+  iam_assume_role_external_id = var.anyscale_cloud_id != null && var.anyscale_cloud_id != "" ? [var.anyscale_cloud_id] : []
 }
 
 # ------------------------------
@@ -137,6 +139,8 @@ module "aws_anyscale_iam" {
   anyscale_iam_s3_policy_name        = local.iam_s3_policy_name
   anyscale_iam_s3_policy_name_prefix = local.iam_s3_policy_prefix
   anyscale_iam_s3_policy_description = var.anyscale_iam_s3_policy_description
+
+  anyscale_trusted_role_sts_externalid = local.iam_assume_role_external_id
 
   anyscale_cloud_id = var.anyscale_cloud_id
   anyscale_org_id   = var.anyscale_org_id


### PR DESCRIPTION
Repetive executions would remove the assume rule condition when anyscale_cloud_id was null or "" - this should keep that from happening.

On branch brent/fix-awsiampolicy
Changes to be committed:
	modified:   CHANGELOG.md
	modified:   main.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
