### PR TITLE
[fix] IAM Policy for Cloudwatch Log/Metric Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.18.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- IAM Policy fix for Cloudwatch Log/Metrics integration.
+
+BREAKING CHANGES:
+
+NOTES:
+
 ## 0.18.0 (Released)
 FEATURES:
 - (Optional) MemoryDB Redis Cluster - this optional submodule creates a MemoryDB Redis Cluster for Anyscale Production Services. There are addditional updates to the VPC Submodule to optionaly create new VPC Subnets for the MemoryDB resource. The MemoryDB functionality provides [head node fault tolerance](https://docs.anyscale.com/productionize/services/head-node-fault-tolerance).

--- a/modules/aws-anyscale-iam/iam-policies-data.tf
+++ b/modules/aws-anyscale-iam/iam-policies-data.tf
@@ -18,14 +18,14 @@ locals {
   cloud_and_org_id_provided = var.anyscale_cloud_id != null && var.anyscale_org_id != null ? true : false
   org_id_provided           = var.anyscale_org_id != null ? true : false
 
-  log_group_cloud_and_org_id_arn = local.cloud_and_org_id_provided ? "arn:aws:logs:*:${local.account_id}:log-group:/anyscale/${var.anyscale_org_id}/${var.anyscale_cloud_id}*" : null
-  log_group_org_id_arn           = local.org_id_provided ? "arn:aws:logs:*:${local.account_id}:log-group:/anyscale/${var.anyscale_org_id}/*" : null
-  log_group_cloud_id_arn         = local.cloud_id_provided ? "arn:aws:logs:*:${local.account_id}:log-group:/anyscale/*/${var.anyscale_cloud_id}*" : null
+  log_group_cloud_and_org_id_arn = local.cloud_and_org_id_provided ? "arn:aws:logs:*:${local.account_id}:log-group:/anyscale*" : null
+  log_group_org_id_arn           = local.org_id_provided ? "arn:aws:logs:*:${local.account_id}:log-group:/anyscale*" : null
+  log_group_cloud_id_arn         = local.cloud_id_provided ? "arn:aws:logs:*:${local.account_id}:log-group:/anyscale*" : null
   log_group_arn = coalesce(
     local.log_group_cloud_and_org_id_arn,
     local.log_group_org_id_arn,
     local.log_group_cloud_id_arn,
-    "arn:aws:logs:*:${local.account_id}:log-group:/anyscale/*"
+    "arn:aws:logs:*:${local.account_id}:log-group:/anyscale*"
   )
 }
 # Allow Anyscale account access to assume this role.


### PR DESCRIPTION
### Bugfix - IAM SubModule

In testing with the latest documentation for [sending logs to
Cloudwatch](https://docs.anyscale.com/integrations/monitoring), we are
no longer enforcing "Organzation" as part of the namespace. This
commit removes that requirement.

On branch brent/iam-cloudwatch-bugfix
Changes to be committed:
	modified:   modules/aws-anyscale-iam/iam-policies-data.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
