### PR TITLE
[upd] kitchensink example and e2e test AWS Provider versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,9 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
+        args:
+          - --tf-init-args=-upgrade
+          - --hook-config=--retry-once-with-cleanup=true # requires jq - cleans up broken .terraform directories
       - id: terraform_tflint
         args:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
@@ -16,10 +19,10 @@ repos:
       - id: terraform_docs
         args:
           - --args=--config=.terraform-docs.yml
-      - id: tfupdate
-        name: Autoupdate Terraform AWS Provider
-        args:
-          - --args=provider aws -v "~> 5.0"
+      # - id: tfupdate
+      #   name: Autoupdate Terraform AWS Provider
+      #   args:
+      #     - --args=provider aws -v "~> 5.16.0"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.18.2 (Released)
+FEATURES:
+
+BUG FIXES:
+- Force AWS Provider to 5.16 in unit test. 5.17 has a bug with deleting S3 content.
+
+BREAKING CHANGES:
+
+NOTES:
+
 ## 0.18.1 (Released)
 FEATURES:
 

--- a/examples/anyscale-v2-kitchensink/README.md
+++ b/examples/anyscale-v2-kitchensink/README.md
@@ -40,7 +40,7 @@ anyscale cloud delete --name <CUSTOMER_DEFINED_NAME>
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.16.0 |
 
 ## Providers
 

--- a/examples/anyscale-v2-kitchensink/versions.tf
+++ b/examples/anyscale-v2-kitchensink/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.16.0"
     }
   }
 }

--- a/test/anyscale-v2-e2e-public-test/versions.tf
+++ b/test/anyscale-v2-e2e-public-test/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.16.0"
     }
   }
 }


### PR DESCRIPTION
The AWS Provider version 5.17.0 has a bug which causes s3 bucket deletion via terraform to fail. This commit updates the kitchensink example and the e2e unit test to use the AWS Provider version 5.16.x.

It also updates pre-commit-config to not update to the lates 5.0 version.

Changes to be committed:
	modified:   .pre-commit-config.yaml
	modified:   CHANGELOG.md
	modified:   examples/anyscale-v2-kitchensink/README.md
	modified:   examples/anyscale-v2-kitchensink/versions.tf
	modified:   test/anyscale-v2-e2e-public-test/versions.tf
	modified:   test/test_cloud_register_manual.py

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix (for AWS Terraform Provider bug)
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
