### PR TITLE
[upd] Cleanup of example outputs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,14 +14,6 @@ Please check if your PR fulfills the following requirements:
 - [ ] Documentation change
 - [ ] Other (please describe):
 
-
-## Description
-<!-- Please describe the current behavior that you are modifying. -->
-<!-- Please describe the behavior or changes that are being added by this PR. -->
--
--
--
-
 ## Does this introduce a breaking change?
 - [ ] Yes
 - [ ] No

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 default_stages: [commit]
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.2
+    rev: v1.83.3
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.26.0"
+  version = "0.27.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 FEATURES:
 
 BUG FIXES:
+
+BREAKING CHANGES:
+
+NOTES:
+- Updates to pre-commit and tflint config files
+- Updates to Pull request template
+- Updates to example outputs for the registration command, making it more readable.
+
+## 0.18.2 (Released)
+FEATURES:
+
+BUG FIXES:
 - Force AWS Provider to 5.16 in unit test. 5.17 has a bug with deleting S3 content.
 
 BREAKING CHANGES:

--- a/examples/anyscale-v2-commonname/outputs.tf
+++ b/examples/anyscale-v2-commonname/outputs.tf
@@ -54,5 +54,16 @@ output "anyscale_register_command" {
     This output can be used with the Anyscale CLI to register a new Anyscale Cloud.
     You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command.
   EOF
-  value       = "anyscale cloud register --provider aws \\\n--name <CUSTOMER_DEFINED_NAME> \\\n--region ${var.aws_region} \\\n--vpc-id ${module.aws_anyscale_v2_common_name.anyscale_vpc_id} \\\n--subnet-ids ${join(",", module.aws_anyscale_v2_common_name.anyscale_vpc_public_subnet_ids)} \\\n--security-group-ids ${module.aws_anyscale_v2_common_name.anyscale_security_group_id} \\\n--s3-bucket-id ${module.aws_anyscale_v2_common_name.anyscale_s3_bucket_id} \\\n--anyscale-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_arn} \\\n--instance-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_cluster_node_arn} \\\n--efs-id ${module.aws_anyscale_v2_common_name.anyscale_efs_id}"
+  value       = <<-EOT
+    anyscale cloud register --provider aws \
+    --name <CUSTOMER_DEFINED_NAME> \
+    --region ${var.aws_region} \
+    --vpc-id ${module.aws_anyscale_v2_common_name.anyscale_vpc_id} \
+    --subnet-ids ${join(",", module.aws_anyscale_v2_common_name.anyscale_vpc_public_subnet_ids)} \
+    --security-group-ids ${module.aws_anyscale_v2_common_name.anyscale_security_group_id} \
+    --s3-bucket-id ${module.aws_anyscale_v2_common_name.anyscale_s3_bucket_id} \
+    --anyscale-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_arn} \
+    --instance-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_cluster_node_arn} \
+    --efs-id ${module.aws_anyscale_v2_common_name.anyscale_efs_id}
+  EOT
 }

--- a/examples/anyscale-v2-existing-s3/outputs.tf
+++ b/examples/anyscale-v2-existing-s3/outputs.tf
@@ -54,5 +54,16 @@ output "anyscale_register_command" {
     This output can be used with the Anyscale CLI to register a new Anyscale Cloud.
     You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command.
   EOF
-  value       = "anyscale cloud register --provider aws \\\n--name <CUSTOMER_DEFINED_NAME> \\\n--region ${var.aws_region} \\\n--vpc-id ${module.aws_anyscale_v2_common_name.anyscale_vpc_id} \\\n--subnet-ids ${join(",", module.aws_anyscale_v2_common_name.anyscale_vpc_public_subnet_ids)} \\\n--security-group-ids ${module.aws_anyscale_v2_common_name.anyscale_security_group_id} \\\n--s3-bucket-id ${module.aws_anyscale_v2_common_name.anyscale_s3_bucket_id} \\\n--anyscale-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_arn} \\\n--instance-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_cluster_node_arn} \\\n--efs-id ${module.aws_anyscale_v2_common_name.anyscale_efs_id}"
+  value       = <<-EOT
+    anyscale cloud register --provider aws \
+    --name <CUSTOMER_DEFINED_NAME> \
+    --region ${var.aws_region} \
+    --vpc-id ${module.aws_anyscale_v2_common_name.anyscale_vpc_id} \
+    --subnet-ids ${join(",", module.aws_anyscale_v2_common_name.anyscale_vpc_public_subnet_ids)} \
+    --security-group-ids ${module.aws_anyscale_v2_common_name.anyscale_security_group_id} \
+    --s3-bucket-id ${module.aws_anyscale_v2_common_name.anyscale_s3_bucket_id} \
+    --anyscale-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_arn} \
+    --instance-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_cluster_node_arn} \
+    --efs-id ${module.aws_anyscale_v2_common_name.anyscale_efs_id}
+  EOT
 }

--- a/examples/anyscale-v2-existing-vpc/outputs.tf
+++ b/examples/anyscale-v2-existing-vpc/outputs.tf
@@ -32,5 +32,16 @@ output "anyscale_register_command" {
     This output can be used with the Anyscale CLI to register a new Anyscale Cloud.
     You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command.
   EOF
-  value       = "anyscale cloud register --provider aws \\\n--name <CUSTOMER_DEFINED_NAME> \\\n--region ${var.aws_region} \\\n--vpc-id ${var.existing_vpc_id} \\\n--subnet-ids ${join(",", var.existing_subnet_ids)} \\\n--security-group-ids ${module.aws_anyscale_v2_existing_vpc.anyscale_security_group_id} \\\n--s3-bucket-id ${module.aws_anyscale_v2_existing_vpc.anyscale_s3_bucket_id} \\\n--anyscale-iam-role-id ${module.aws_anyscale_v2_existing_vpc.anyscale_iam_role_arn} \\\n--instance-iam-role-id ${module.aws_anyscale_v2_existing_vpc.anyscale_iam_role_cluster_node_arn} \\\n--efs-id ${module.aws_anyscale_v2_existing_vpc.anyscale_efs_id}"
+  value       = <<-EOT
+    anyscale cloud register --provider aws \
+    --name <CUSTOMER_DEFINED_NAME> \
+    --region ${var.aws_region} \
+    --vpc-id ${var.existing_vpc_id} \
+    --subnet-ids ${join(",", var.existing_subnet_ids)} \
+    --security-group-ids ${module.aws_anyscale_v2_existing_vpc.anyscale_security_group_id} \
+    --s3-bucket-id ${module.aws_anyscale_v2_existing_vpc.anyscale_s3_bucket_id} \
+    --anyscale-iam-role-id ${module.aws_anyscale_v2_existing_vpc.anyscale_iam_role_arn} \
+    --instance-iam-role-id ${module.aws_anyscale_v2_existing_vpc.anyscale_iam_role_cluster_node_arn} \
+    --efs-id ${module.aws_anyscale_v2_existing_vpc.anyscale_efs_id}
+  EOT
 }

--- a/examples/anyscale-v2-kitchensink/README.md
+++ b/examples/anyscale-v2-kitchensink/README.md
@@ -73,5 +73,4 @@ No resources.
 | Name | Description |
 |------|-------------|
 | <a name="output_anyscale_register_command"></a> [anyscale\_register\_command](#output\_anyscale\_register\_command) | Anyscale register command.<br>This output can be used with the Anyscale CLI to register a new Anyscale Cloud.<br>You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command. |
-| <a name="output_memorydb_address_for_anyscaleservices"></a> [memorydb\_address\_for\_anyscaleservices](#output\_memorydb\_address\_for\_anyscaleservices) | Anyscale MemoryDB Cluster Address. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/anyscale-v2-kitchensink/outputs.tf
+++ b/examples/anyscale-v2-kitchensink/outputs.tf
@@ -7,10 +7,18 @@ output "anyscale_register_command" {
     This output can be used with the Anyscale CLI to register a new Anyscale Cloud.
     You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command.
   EOF
-  value       = "anyscale cloud register --provider aws \\\n--name <CUSTOMER_DEFINED_NAME> \\\n--region ${var.aws_region} \\\n--vpc-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_vpc_id} \\\n--subnet-ids ${join(",", module.aws_anyscale_v2_kitchen_sink.anyscale_vpc_private_subnet_ids)} \\\n--security-group-ids ${module.aws_anyscale_v2_kitchen_sink.anyscale_security_group_id} \\\n--s3-bucket-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_s3_bucket_id} \\\n--anyscale-iam-role-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_iam_role_arn} \\\n--instance-iam-role-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_iam_role_cluster_node_arn} \\\n--efs-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_efs_id} \\\n--memorydb-cluster-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_memorydb_cluster_id} \\\n--private-network"
-}
-
-output "memorydb_address_for_anyscaleservices" {
-  description = "Anyscale MemoryDB Cluster Address."
-  value       = try("${module.aws_anyscale_v2_kitchen_sink.anyscale_memorydb_cluster_endpoint_address}:${module.aws_anyscale_v2_kitchen_sink.anyscale_memorydb_cluster_endpoint_port}", "")
+  value       = <<-EOT
+    anyscale cloud register --provider aws \
+    --name <CUSTOMER_DEFINED_NAME> \
+    --region ${var.aws_region} \
+    --vpc-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_vpc_id} \
+    --subnet-ids ${join(",", module.aws_anyscale_v2_kitchen_sink.anyscale_vpc_private_subnet_ids)} \
+    --security-group-ids ${module.aws_anyscale_v2_kitchen_sink.anyscale_security_group_id} \
+    --s3-bucket-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_s3_bucket_id} \
+    --anyscale-iam-role-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_iam_role_arn} \
+    --instance-iam-role-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_iam_role_cluster_node_arn} \
+    --efs-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_efs_id} \
+    --memorydb-cluster-id ${module.aws_anyscale_v2_kitchen_sink.anyscale_memorydb_cluster_id} \
+    --private-network
+  EOT
 }

--- a/examples/anyscale-v2-privatesubnets/outputs.tf
+++ b/examples/anyscale-v2-privatesubnets/outputs.tf
@@ -47,5 +47,18 @@ output "memorydb_address_for_anyscaleservices" {
 
 output "anyscale_register_command" {
   description = "Anyscale register command."
-  value       = "anyscale cloud register --provider aws \\\n--name <CUSTOMER_DEFINED_NAME> \\\n--region ${var.aws_region} \\\n--vpc-id ${module.aws_anyscale_v2_private_vpc.anyscale_vpc_id} \\\n--subnet-ids ${join(",", module.aws_anyscale_v2_private_vpc.anyscale_vpc_private_subnet_ids)} \\\n--security-group-ids ${module.aws_anyscale_v2_private_vpc.anyscale_security_group_id} \\\n--s3-bucket-id ${module.aws_anyscale_v2_private_vpc.anyscale_s3_bucket_id} \\\n--anyscale-iam-role-id ${module.aws_anyscale_v2_private_vpc.anyscale_iam_role_arn} \\\n--instance-iam-role-id ${module.aws_anyscale_v2_private_vpc.anyscale_iam_role_cluster_node_arn} \\\n--efs-id ${module.aws_anyscale_v2_private_vpc.anyscale_efs_id} \\\n--memorydb-cluster-id ${module.aws_anyscale_v2_private_vpc.anyscale_memorydb_cluster_id} \\\n--private-network"
+  value       = <<-EOT
+    anyscale cloud register --provider aws \
+    --name <CUSTOMER_DEFINED_NAME> \
+    --region ${var.aws_region} \
+    --vpc-id ${module.aws_anyscale_v2_private_vpc.anyscale_vpc_id} \
+    --subnet-ids ${join(",", module.aws_anyscale_v2_private_vpc.anyscale_vpc_private_subnet_ids)} \
+    --security-group-ids ${module.aws_anyscale_v2_private_vpc.anyscale_security_group_id} \
+    --s3-bucket-id ${module.aws_anyscale_v2_private_vpc.anyscale_s3_bucket_id} \
+    --anyscale-iam-role-id ${module.aws_anyscale_v2_private_vpc.anyscale_iam_role_arn} \
+    --instance-iam-role-id ${module.aws_anyscale_v2_private_vpc.anyscale_iam_role_cluster_node_arn} \
+    --efs-id ${module.aws_anyscale_v2_private_vpc.anyscale_efs_id} \
+    --memorydb-cluster-id ${module.aws_anyscale_v2_private_vpc.anyscale_memorydb_cluster_id} \
+    --private-network
+  EOT
 }

--- a/examples/anyscale-v2/outputs.tf
+++ b/examples/anyscale-v2/outputs.tf
@@ -47,5 +47,16 @@ output "anyscale_register_command" {
     This output can be used with the Anyscale CLI to register a new Anyscale Cloud.
     You will need to replace `<CUSTOMER_DEFINED_NAME>` with a name of your choosing before running the Anyscale CLI command.
   EOF
-  value       = "anyscale cloud register --provider aws \\\n--name <CUSTOMER_DEFINED_NAME> \\\n--region ${var.aws_region} \\\n--vpc-id ${module.aws_anyscale_v2.anyscale_vpc_id} \\\n--subnet-ids ${join(",", module.aws_anyscale_v2.anyscale_vpc_public_subnet_ids)} \\\n--security-group-ids ${module.aws_anyscale_v2.anyscale_security_group_id} \\\n--s3-bucket-id ${module.aws_anyscale_v2.anyscale_s3_bucket_id} \\\n--anyscale-iam-role-id ${module.aws_anyscale_v2.anyscale_iam_role_arn} \\\n--instance-iam-role-id ${module.aws_anyscale_v2.anyscale_iam_role_cluster_node_arn} \\\n--efs-id ${module.aws_anyscale_v2.anyscale_efs_id}"
+  value       = <<-EOT
+  anyscale cloud register --provider aws \
+  --name <CUSTOMER_DEFINED_NAME> \
+  --region ${var.aws_region} \
+  --vpc-id ${module.aws_anyscale_v2.anyscale_vpc_id} \
+  --subnet-ids ${join(",", module.aws_anyscale_v2.anyscale_vpc_public_subnet_ids)} \
+  --security-group-ids ${module.aws_anyscale_v2.anyscale_security_group_id} \
+  --s3-bucket-id ${module.aws_anyscale_v2.anyscale_s3_bucket_id} \
+  --anyscale-iam-role-id ${module.aws_anyscale_v2.anyscale_iam_role_arn} \
+  --instance-iam-role-id ${module.aws_anyscale_v2.anyscale_iam_role_cluster_node_arn} \
+  --efs-id ${module.aws_anyscale_v2.anyscale_efs_id}
+  EOT
 }


### PR DESCRIPTION
Cleaned up the example outputs so that the anyscale cloud registration command is easier to read and copy/paste.

Additional updates to pre-commit and tflint versions and an update to the pull request template.

<details>
On branch brent/example-outputs
Changes to be committed:
	modified:   .github/PULL_REQUEST_TEMPLATE.md
	modified:   .pre-commit-config.yaml
	modified:   .tflint.hcl
	modified:   CHANGELOG.md
	modified:   examples/anyscale-v2-commonname/outputs.tf
	modified:   examples/anyscale-v2-existing-s3/outputs.tf
	modified:   examples/anyscale-v2-existing-vpc/outputs.tf
	modified:   examples/anyscale-v2-kitchensink/README.md
	modified:   examples/anyscale-v2-kitchensink/outputs.tf
	modified:   examples/anyscale-v2-privatesubnets/outputs.tf
	modified:   examples/anyscale-v2/outputs.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation change
- [x] Other (please describe):
Cleanup of example outputs, pre-commit and tflint updates

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
</details>