### PR TITLE
fix: Existing S3 bucket functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.19.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- Fix issue with IAM policy creation when passing in an existing S3 Bucket.
+- Fix Existing S3 example - Output update to use variable for s3 bucket id.
+
+BREAKING CHANGES:
+
+NOTES:
+
 ## 0.19.0 (Released)
 FEATURES:
 - Updates to EFS outputs to include IPs

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We use GitHub [Issues] to track community reported issues and missing features.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
 ## Modules
 

--- a/examples/anyscale-v2-existing-s3/README.md
+++ b/examples/anyscale-v2-existing-s3/README.md
@@ -50,7 +50,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_anyscale_v2_common_name"></a> [aws\_anyscale\_v2\_common\_name](#module\_aws\_anyscale\_v2\_common\_name) | ../.. | n/a |
+| <a name="module_aws_anyscale_v2_existing_s3"></a> [aws\_anyscale\_v2\_existing\_s3](#module\_aws\_anyscale\_v2\_existing\_s3) | ../.. | n/a |
 
 ## Resources
 

--- a/examples/anyscale-v2-existing-s3/main.tf
+++ b/examples/anyscale-v2-existing-s3/main.tf
@@ -1,9 +1,8 @@
 # ---------------------------------------------------------------------------------------------------------------------
-# Create core Anyscale v2 Stack resources with minimal parameters but a common name
+# Create core Anyscale v2 Stack resources with minimal parameters but use an existing S3 Bucket
 #   Should be executed in us-east-2
 #   Creates a v2 stack including
 #     - IAM Roles
-#     - S3 Bucket
 #     - VPC with publicly routed subnets (no private subnets)
 #     - VPC Security Groups
 #     - EFS
@@ -17,7 +16,7 @@ locals {
   )
 }
 
-module "aws_anyscale_v2_common_name" {
+module "aws_anyscale_v2_existing_s3" {
   source = "../.." #this should be changed if executing this example outside of this repository
   tags   = local.full_tags
 

--- a/examples/anyscale-v2-existing-s3/outputs.tf
+++ b/examples/anyscale-v2-existing-s3/outputs.tf
@@ -3,49 +3,49 @@
 # ---------------------------------------------------------------------------------------------------------------------
 output "anyscale_v2_vpc_id" {
   description = "Anyscale VPC ID. If there was not one created, return the one that was used during other resource creation."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_id, "")
+  value       = try(module.aws_anyscale_v2_existing_s3.anyscale_vpc_id, "")
 }
 
 output "anyscale_v2_public_routetable_ids" {
   description = "Anyscale VPC Public Route Table IDs. If none were created, return an empty string."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_public_routetable_ids, [])
+  value       = try(module.aws_anyscale_v2_existing_s3.anyscale_vpc_public_routetable_ids, [])
 }
 output "anyscale_v2_public_subnet_ids" {
   description = "Anyscale VPC Public Subnet IDs. If there were none created, return an empty string."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_public_subnet_ids, [])
+  value       = try(module.aws_anyscale_v2_existing_s3.anyscale_vpc_public_subnet_ids, [])
 }
 output "anyscale_v2_private_routetable_ids" {
   description = "Anyscale VPC Private Route Table IDs. If none were created, return an empty string."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_private_routetable_ids, [])
+  value       = try(module.aws_anyscale_v2_existing_s3.anyscale_vpc_private_routetable_ids, [])
 }
 output "anyscale_v2_private_subnet_ids" {
   description = "Anyscale VPC Private Subnet IDs. If there were none created, return an empty string."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_vpc_private_subnet_ids, [])
+  value       = try(module.aws_anyscale_v2_existing_s3.anyscale_vpc_private_subnet_ids, [])
 }
 
 output "anyscale_v2_s3_bucket_id" {
   description = "Anyscale S3 Bucket ID. If a bucket was not created, return an empty string."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_s3_bucket_id, "")
+  value       = split(":", var.existing_s3_bucket_arn)[5]
 }
 
 output "anyscale_v2_security_group_id" {
   description = "Anyscale Security Group ID. If a security group was not created, return an empty string."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_security_group_id, "")
+  value       = try(module.aws_anyscale_v2_existing_s3.anyscale_security_group_id, "")
 }
 
 output "anyscale_v2_iam_role_arn" {
   description = "Anyscale IAM access role arn."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_iam_role_arn, "")
+  value       = try(module.aws_anyscale_v2_existing_s3.anyscale_iam_role_arn, "")
 }
 
 output "anyscale_v2_iam_instance_role_arn" {
   description = "Anyscale IAM instance role arn."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_iam_role_cluster_node_arn, "")
+  value       = try(module.aws_anyscale_v2_existing_s3.anyscale_iam_role_cluster_node_arn, "")
 }
 
 output "anyscale_v2_efs_id" {
   description = "Anyscale Elastic File System ID."
-  value       = try(module.aws_anyscale_v2_common_name.anyscale_efs_id, "")
+  value       = try(module.aws_anyscale_v2_existing_s3.anyscale_efs_id, "")
 }
 
 output "anyscale_register_command" {
@@ -58,12 +58,12 @@ output "anyscale_register_command" {
     anyscale cloud register --provider aws \
     --name <CUSTOMER_DEFINED_NAME> \
     --region ${var.aws_region} \
-    --vpc-id ${module.aws_anyscale_v2_common_name.anyscale_vpc_id} \
-    --subnet-ids ${join(",", module.aws_anyscale_v2_common_name.anyscale_vpc_public_subnet_ids)} \
-    --security-group-ids ${module.aws_anyscale_v2_common_name.anyscale_security_group_id} \
-    --s3-bucket-id ${module.aws_anyscale_v2_common_name.anyscale_s3_bucket_id} \
-    --anyscale-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_arn} \
-    --instance-iam-role-id ${module.aws_anyscale_v2_common_name.anyscale_iam_role_cluster_node_arn} \
-    --efs-id ${module.aws_anyscale_v2_common_name.anyscale_efs_id}
+    --vpc-id ${module.aws_anyscale_v2_existing_s3.anyscale_vpc_id} \
+    --subnet-ids ${join(",", module.aws_anyscale_v2_existing_s3.anyscale_vpc_public_subnet_ids)} \
+    --security-group-ids ${module.aws_anyscale_v2_existing_s3.anyscale_security_group_id} \
+    --s3-bucket-id ${split(":", var.existing_s3_bucket_arn)[5]} \
+    --anyscale-iam-role-id ${module.aws_anyscale_v2_existing_s3.anyscale_iam_role_arn} \
+    --instance-iam-role-id ${module.aws_anyscale_v2_existing_s3.anyscale_iam_role_cluster_node_arn} \
+    --efs-id ${module.aws_anyscale_v2_existing_s3.anyscale_efs_id}
   EOT
 }

--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ module "aws_anyscale_iam" {
   anyscale_cluster_node_managed_policy_arns = var.anyscale_cluster_node_managed_policy_arns
 
   create_iam_s3_policy               = local.create_new_s3_bucket || var.existing_s3_bucket_arn != null ? true : false
-  anyscale_s3_bucket_arn             = try(module.aws_anyscale_s3.s3_bucket_arn, var.existing_s3_bucket_arn, null)
+  anyscale_s3_bucket_arn             = try(coalesce(var.existing_s3_bucket_arn, module.aws_anyscale_s3.s3_bucket_arn), null)
   anyscale_iam_s3_policy_name        = local.iam_s3_policy_name
   anyscale_iam_s3_policy_name_prefix = local.iam_s3_policy_prefix
   anyscale_iam_s3_policy_description = var.anyscale_iam_s3_policy_description


### PR DESCRIPTION
Using an existing S3 bucket via the example `anyscale-v2-existing-s3` was broken with the latest versions of Terraform due to an invalid IAM policy reference to the S3 bucket name. This fixes that - and updates the example to provide a working output command that can be used to register an Anyscale Cloud.

On branch brent/fix-existings3
Changes to be committed:
	modified:   CHANGELOG.md
	modified:   README.md
	modified:   examples/anyscale-v2-existing-s3/README.md
	modified:   examples/anyscale-v2-existing-s3/main.tf
	modified:   examples/anyscale-v2-existing-s3/outputs.tf
	modified:   main.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

