### PR TITLE
fix: Example documentation for KMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![AWS Provider Version][badge-tf-aws]](https://github.com/terraform-providers/terraform-provider-aws/releases)
 
 # Terraform Modules for Anyscale Cloud Foundations on AWS
-[Terraform] modules to manage cloud infrastructure for Anyscale. This builds the foundational cloud resources needed to run Anyscale in a cloud environment. This module and sub-modules support Google Cloud.
+[Terraform] modules to manage cloud infrastructure for Anyscale. This builds the foundational cloud resources needed to run Anyscale in a cloud environment. This module and sub-modules support AWS Cloud.
 
 **THIS IS PROVIDED AS A STARTING POINT**
 

--- a/examples/anyscale-v2-kms/README.md
+++ b/examples/anyscale-v2-kms/README.md
@@ -1,21 +1,21 @@
 # Anyscale Networking Stack v2 - KMS Encryption for S3 and EFS
 
-This **example** will build the resources necessary to run Anyscale in an AWS account. This example will build a
+This **example** will build the resources necessary to run Anyscale in an AWS account. This example will create a
 [Direct Networking](https://docs.anyscale.com/cloud-deployment/aws/manage-clouds#anyscale-clouds-on-aws) solution.
 
-EFS and S3 will use a common KMS Key, however each of these could be unique.
+In this example, the EFS and S3 will use a shared KMS Key; however, each could be unique.
 
 ## To execute
-A general understanding of Terraform and AWS are useful for executing this Terraform. For a high level overview of both,
-please see the [getting started guide](https://github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules/blob/main/getting-started.md).
+A general understanding of Terraform and AWS is helpful for understanding how to execute this Terraform. For a high-level overview of both,
+please see the [Getting Started guide](https://github.com/anyscale/terraform-aws-anyscale-cloudfoundation-modules/blob/main/getting-started.md).
 
-## Using with Anyscale CLI
+## Using with the Anyscale CLI
 
 The outputs from this Terraform can be used to build an anyscale cloud with the anyscale CLI. To use:
 1. Make sure you have the latest Anyscale CLI installed `pip install anyscale --upgrade`
-2. The terraform output, `anyscale_register_command` will provide an example Anyscale CLI command that can be used to register an Anyscale Cloud. You will need to change `<CUSTOMER_DEFINED_NAME>` to a cloud name that you would like to use.
+2. The terraform output: `anyscale_register_command` will provide an example of an Anyscale CLI command you can use to register an Anyscale Cloud. You must change the value: `<CUSTOMER_DEFINED_NAME>` to a cloud name you would like to use.
 
-example:
+Example:
 
 ```
 anyscale cloud register --provider aws \

--- a/examples/anyscale-v2-kms/main.tf
+++ b/examples/anyscale-v2-kms/main.tf
@@ -1,6 +1,5 @@
 # ---------------------------------------------------------------------------------------------------------------------
 # Create core Anyscale v2 Stack resources with minimal parameters but a common name
-#   Should be executed in us-east-2
 #   Creates a v2 stack including
 #     - IAM Roles
 #     - S3 Bucket


### PR DESCRIPTION
Removed reference to `us-east-2` in KMS example.
General cleanup on language and formatting in KMS example.

On branch brent/example-kms-cleanup
Changes to be committed:
	modified:   examples/anyscale-v2-kms/README.md
	modified:   examples/anyscale-v2-kms/main.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
