### PR TITLE
fix: EKS Nodegroups - Use pinned version from Scaling Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.22.1 (Released)
+FEATURES:
+- Add initial support for Anyscale on EKS.
+
+BUG FIXES:
+- Update EKS Node Group autoscaling template vesion assignment so that Terraform doesn't detect changes on every apply.
+
+BREAKING CHANGES:
+
+NOTES:
+
 ## 0.22.0 (Released)
 FEATURES:
 - Add initial support for Anyscale on EKS.

--- a/modules/aws-anyscale-eks-nodegroups/main.tf
+++ b/modules/aws-anyscale-eks-nodegroups/main.tf
@@ -91,7 +91,7 @@ resource "aws_eks_node_group" "anyscale_node_groups" {
 
   launch_template {
     id      = aws_launch_template.anyscale_node_groups[0].id
-    version = "$Latest"
+    version = aws_launch_template.anyscale_node_groups[0].latest_version
   }
 
   scaling_config {

--- a/modules/aws-anyscale-iam/iam-policies-data.tf
+++ b/modules/aws-anyscale-iam/iam-policies-data.tf
@@ -52,6 +52,7 @@ data "aws_iam_policy_document" "iam_anyscale_crossacct_assumerole_policy" {
 
 #Allow wildcard resources as these are locked down in other ways
 #trivy:ignore:avd-aws-0342 trivy:ignore:avd-aws-0057
+#trivy:ignore:avd-aws-0342 trivy:ignore:avd-aws-0342
 data "aws_iam_policy_document" "iam_anyscale_steadystate_policy" {
   #checkov:skip=CKV_AWS_111:Write access required for these items
   #checkov:skip=CKV_AWS_356:Wildcards allowed for these items


### PR DESCRIPTION
The original release of this used $LATEST which was causing each terraform apply to recalculate the launch template and update the nodegroups, even when there were no changes.

This now utilizes the `latest_version` attribute from the `aws_launch_template`

Changes to be committed:
	modified:   CHANGELOG.md
	modified:   modules/aws-anyscale-eks-nodegroups/main.tf
	modified:   modules/aws-anyscale-iam/iam-policies-data.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

