### PR TITLE
upd: IAM and S3 Policy Updates for new dependency tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## 0.23.0 (Released)
+## 0.25.0 (Released)
+FEATURES:
+- Updates to least priveledged IAM policy for the Control Plane Role
+  - Add permissions for new dependency tracking functionality on Anyscale Workspaces
+
+BUG FIXES:
+
+BREAKING CHANGES:
+
+NOTES:
+
+## 0.24.0 (Released)
 FEATURES:
 - Updates to least priveledged IAM policy for the Control Plane Role
   - When passing in a Cloud ID, additional IAM conditions can be applied for EBS Volumes and IAM Instance Profile associations based on the Cloud ID tag.

--- a/modules/aws-anyscale-iam/s3-bucket-access.tmpl
+++ b/modules/aws-anyscale-iam/s3-bucket-access.tmpl
@@ -5,10 +5,14 @@
       "Sid": "S3BucketAccess",
       "Effect" : "Allow",
       "Action" : [
-        "s3:ListBucket",
-        "s3:GetObject",
         "s3:PutObject",
-        "s3:DeleteObject"
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListMultipartUploadParts",
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation"
       ],
       "Resource": [
         "${anyscale_s3_bucket_arn}",

--- a/modules/aws-anyscale-s3-policy/predefined_s3_policy.tpl
+++ b/modules/aws-anyscale-s3-policy/predefined_s3_policy.tpl
@@ -25,7 +25,11 @@
         "s3:PutObject",
         "s3:DeleteObject",
         "s3:GetObject",
-        "s3:ListBucket"
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListMultipartUploadParts",
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation"
       ],
       "Resource": [
         "arn:aws:s3:::${anyscale_bucket_name}",


### PR DESCRIPTION
Anyscale is releasing a new dependency tracking feature for Ansycale Workspaces. This new functionality requires additional permissions for the S3 bucket including:
- s3:ListBucketMultipartUploads
- s3:ListMultipartUploadParts
- s3:AbortMultipartUpload
- s3:GetBucketLocation

On branch brent/upd-s3-access
Changes to be committed:
	modified:   CHANGELOG.md
	modified:   modules/aws-anyscale-iam/s3-bucket-access.tmpl
	modified:   modules/aws-anyscale-s3-policy/predefined_s3_policy.tpl

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

