### PR TITLE
fix: Multi-AZ EFS mount targets in same AZ subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.23.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- This updates the main base module to only send one subnet per AZ to the EFS sub-module. The EFS sub-module would throw an error when using an existing VPC with multiple subnets in the same AZ.
+
+BREAKING CHANGES:
+
+NOTES:
+
 ## 0.23.0 (Released)
 FEATURES:
 - Updates to least priveledged IAM policy for the Control Plane Role

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ We use GitHub [Issues] to track community reported issues and missing features.
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.41.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
 ## Modules
@@ -146,6 +147,7 @@ We use GitHub [Issues] to track community reported issues and missing features.
 | Name | Type |
 |------|------|
 | [random_id.common_name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_subnet.existing_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
 

--- a/modules/aws-anyscale-securitygroups/main.tf
+++ b/modules/aws-anyscale-securitygroups/main.tf
@@ -169,8 +169,9 @@ resource "aws_security_group_rule" "ingress_with_existing_security_groups" {
 # Security Group Egress Rules
 # -----------------------------
 # Security group rule - ALL egress
-#trivy:ignore:avd-aws-0104:Allow all egress traffic is a valid use case. Ignoring this alert.
+#trivy:ignore:avd-aws-0104:Egress is required to the internet for the Anyscale Control Plane and other services.
 resource "aws_security_group_rule" "egress_all_allowed" {
+  #checkov:skip=CKV_AWS_382:Egress is required to the internet for the Anyscale Control Plane and other services.
   count = local.allow_all_egress ? 1 : 0
 
   security_group_id = local.security_group_id


### PR DESCRIPTION
When creating EFS mount targets in subnets that are in the same AZ, the mount target configuration would fail. While Anyscale does not recommend using mutliple subnets in the same AZ, this fixes the scenario where the submodule would fail.

On branch brent/fix-efs-sameazsubnets
Changes to be committed:
	modified:   CHANGELOG.md
	modified:   README.md
	modified:   main.tf
	modified:   modules/aws-anyscale-securitygroups/main.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
