### PR TITLE
Modify anyscale_external_id variable in documentation

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -73,7 +73,7 @@ Create a `terraform.tfvars` file in the example directory to store your project-
 ```
 aws_region           = "<aws_region_you_want_to_use>"
 common_prefix        = "anyscale-tf-"
-anyscale_external_id = "<anyscale_org_id>-<custom_external_id>"
+anyscale_external_id = "<custom_external_id>"
 
 customer_ingress_cidr_ranges = "0.0.0.0/0"
 ```


### PR DESCRIPTION

<img width="1458" height="236" alt="Screenshot 2026-02-12 at 5 06 28 PM" src="https://github.com/user-attachments/assets/93505adb-14f6-4b59-ac9a-828609767c74" />
Updated the anyscale_external_id variable format in getting-started.md.
The existing format creates a duplicate of org-id as shown in ss

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] pre-commit has been run
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] All tests passing
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots. -->
