### PR TITLE
Bump e2e test examples to AWS provider 6.x

### DIFF
--- a/test/anyscale-v2-e2e-public-services-test/versions.tf
+++ b/test/anyscale-v2-e2e-public-services-test/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.16.0"
+      version = ">= 6.37.0, < 7.0"
     }
   }
 }

--- a/test/anyscale-v2-e2e-public-test/versions.tf
+++ b/test/anyscale-v2-e2e-public-test/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.16.0"
+      version = ">= 6.37.0, < 7.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

The e2e test examples `test/anyscale-v2-e2e-public-test` and `test/anyscale-v2-e2e-public-services-test` still pinned the AWS provider to `~> 5.16.0`. That pin was a 2023 workaround (commit `5e6451c`) for the provider **5.17.0** S3-bucket-delete regression — `OperationAborted: A conflicting conditional operation…` — which was fixed in **5.18.0** (hashicorp/terraform-provider-aws#33531).

Since #92 raised the root module + `aws-anyscale-s3` submodule AWS provider requirement to `>= 6.37.0, < 7.0` (for the `bucket_namespace` feature), the stale `~> 5.16.0` pin makes provider resolution **unsatisfiable** — `terraform init` fails immediately with:

> no available releases match the given constraints `>= 5.0.0, ~> 5.16.0, >= 6.37.0, < 7.0.0`

This broke the `anyscale-v2-e2e-public` cloud-register e2e test in Anyscale predeploy CI (and would break the services variant). Both examples are now aligned with the modules' `>= 6.37.0, < 7.0` constraint. The original 5.17.0 bug is long fixed (5.18.0 — far below 6.37.0), so the pin is obsolete.